### PR TITLE
Use Float from external num module.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,17 @@ readme = "README.md"
 
 [features]
 default = [ "float" ]
-float = []
+float = ["num"]
 
 [lib]
 name = "introsort"
 path = "src/lib.rs"
 test = false
 bench = false
+
+[dependencies.num]
+version = "*"
+optional = true
 
 [dev-dependencies]
 rand = "0.3.7"

--- a/src/float.rs
+++ b/src/float.rs
@@ -1,6 +1,6 @@
 use super::sort::{sort_by};
 use core::prelude::*;
-use core::num::Float;
+use num::{Float,zero};
 use core::intrinsics::unreachable;
 
 /// Sorts floating point number.
@@ -53,10 +53,10 @@ pub fn sort_floats<T: Float>(v: &mut [T]) {
     let mut zeros = 0;
     let mut neg_zeros = 0;
     for x in v[left..].iter() {
-        if *x != Float::zero() {
+        if *x != zero() {
             break;
         }
-        if x.is_negative() {
+        if x.is_sign_negative() {
             neg_zeros += 1;
         } else {
             zeros += 1;
@@ -67,7 +67,7 @@ pub fn sort_floats<T: Float>(v: &mut [T]) {
             *x = Float::neg_zero();
             neg_zeros -= 1;
         } else if zeros > 0 {
-             *x = Float::zero();
+             *x = zero();
              zeros -= 1;
         } else {
             break;
@@ -84,14 +84,14 @@ fn find_first_zero<T: Float>(v: &[T]) -> usize {
 
     while left < hi {
         let mid = ((hi - left) / 2) + left;
-        if v[mid] < Float::zero() {
+        if v[mid] < zero() {
             left = mid + 1;
         } else {
             hi = mid;
         }
     }
 
-    while left < v.len() && v[left] < Float::zero() {
+    while left < v.len() && v[left] < zero() {
         left += 1;
     }
     return left;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@
 
 extern crate core;
 
+#[cfg(feature  = "float")]
+extern crate num;
+
 pub use sort::{sort, sort_by, insertion_sort, heapsort};
 #[cfg(feature = "float")]
 pub use float::{sort_floats};

--- a/tests/test-floats.rs
+++ b/tests/test-floats.rs
@@ -1,12 +1,14 @@
-#![feature(core)]
 extern crate introsort;
 extern crate rand;
+
+#[cfg(feature = "float")]
+extern crate num;
 
 #[cfg(feature = "float")]
 mod bench {
 
 use std::f64;
-use std::num::{ToPrimitive};
+use num::traits::{ToPrimitive};
 use introsort::{sort_floats};
 use rand::{Rng, weak_rng};
 


### PR DESCRIPTION
Didn't compile with nightly any more because the Float trait was deprecated and now lives in the external `num` package. Not sure if you want to accept this pull request, since it introduces a new dependency, including a transitive dependency on the standard library.

----

The std::num::Float trait was deprecated in favour of the traits in
rust-lang/num. While the standard library provides One and Zero traits
now, std is now missing fp-specific generic methods like is_nan.

Thus, I have added a dependency on the external `num` crate,
gated by the `float` feature of course.

Unfortunately, the `num` crate comes with dependencies on `rand` and `rustc_serialize`,
which reintroduces a dependency on the standard library. (--no-default-features remains core-only)