### PR TITLE
Fix for current nightly.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: rust
+rust:
+  - nightly
 script:
   - cargo build -v
   - cargo test -v

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ path = "src/lib.rs"
 test = false
 bench = false
 
+[dependencies]
+unreachable = "0.0.2"
+
 [dependencies.num]
 version = "0.1.25"
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 [features]
 default = [ "float" ]
-float = ["num"]
+float = ["num", "unreachable"]
 
 [lib]
 name = "introsort"
@@ -20,8 +20,9 @@ path = "src/lib.rs"
 test = false
 bench = false
 
-[dependencies]
-unreachable = "0.0.2"
+[dependencies.unreachable]
+version = "0.0.2"
+optional = true
 
 [dependencies.num]
 version = "0.1.25"

--- a/src/float.rs
+++ b/src/float.rs
@@ -1,7 +1,7 @@
 use super::sort::{sort_by};
 use core::prelude::*;
 use num::{Float,zero};
-use core::intrinsics::unreachable;
+use unreachable::unreachable;
 
 /// Sorts floating point number.
 /// The ordering used is

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,10 @@
 #![feature(unboxed_closures)]
 #![feature(no_std)]
 #![feature(core)]
+#![feature(core_prelude)]
 
 extern crate core;
+extern crate unreachable;
 
 #[cfg(feature  = "float")]
 extern crate num;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,12 @@
 #![feature(no_std)]
 #![feature(core)]
 #![feature(core_prelude)]
+#![feature(core_slice_ext)]
 
 extern crate core;
-extern crate unreachable;
 
+#[cfg(feature  = "float")]
+extern crate unreachable;
 #[cfg(feature  = "float")]
 extern crate num;
 


### PR DESCRIPTION
* No point in using core::intrinsics, when we have a stable version.
* To use core prelude, it's now a separate feature.