### PR TITLE
Remove import/reference to core.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,7 @@
 
 #![feature(unboxed_closures)]
 #![feature(no_std)]
-#![feature(core)]
-
-extern crate core;
+#![feature(core_slice_ext)]
 
 pub use sort::{sort, sort_by, insertion_sort, heapsort};
 #[cfg(feature = "float")]

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -1,4 +1,3 @@
-use core::prelude::*;
 use core::cmp::Ordering;
 use core::cmp::Ordering::*;
 use core::cmp::{min, max};


### PR DESCRIPTION
They seem to be implicit now, causing build errors and warnings on
rustc nightly builds.
This patch does not touch the float module. 