### PR TITLE
Fix errors about duplicate core crate import.

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -59,8 +59,8 @@ fn sort_big_sorted(b: &mut Bencher) {
 #[bench]
 fn sort_few_unique(b: &mut Bencher) {
     let mut v = Vec::new();
-    for i in (0u32 .. 10) {
-        for _ in (0usize .. 100) {
+    for i in 0u32 .. 10 {
+        for _ in 0usize .. 100 {
             v.push(i);
         }
     }
@@ -151,7 +151,7 @@ fn sort_strings(b: &mut Bencher) {
     let n = 10_000usize;
     let mut v = Vec::with_capacity(n);
     let mut bytes = 0;
-    for _ in (0 .. n) {
+    for _ in 0 .. n {
         let len = rng.gen_range(0, 60);
         bytes += len;
         let mut s = String::with_capacity(len);
@@ -159,7 +159,7 @@ fn sort_strings(b: &mut Bencher) {
             v.push(s);
             continue;
         }
-        for _ in (0 .. len) {
+        for _ in 0 .. len {
             s.push(rng.gen_range(b'a', b'z') as char);
         }
         v.push(s);

--- a/src/float.rs
+++ b/src/float.rs
@@ -1,5 +1,4 @@
 use super::sort::{sort_by};
-use core::prelude::*;
 use num::{Float,zero};
 use unreachable::unreachable;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,8 @@
 
 #![feature(unboxed_closures)]
 #![feature(no_std)]
-#![feature(core)]
-#![feature(core_prelude)]
-#![feature(core_slice_ext)]
 
-extern crate core;
+#![feature(core_slice_ext)]
 
 #[cfg(feature  = "float")]
 extern crate unreachable;

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -1,4 +1,3 @@
-use core::prelude::*;
 use core::cmp::Ordering;
 use core::cmp::Ordering::*;
 use core::cmp::{min, max};

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -13,7 +13,7 @@ macro_rules! do_test_sort(
         let cmp = |a: &usize, b: &usize| a.cmp(b);
         let cmp_rev = |a: &usize, b: &usize| b.cmp(a);
         for len in (4usize .. 250).step_by(5) {
-            for _ in (0isize .. 100) {
+            for _ in 0isize .. 100 {
                 let mut v = weak_rng().gen_iter::<u8>().take(len).map(|x| 10 + (x % 89) as usize)
                                         .collect::<Vec<usize>>();
                 let mut v1 = v.clone();


### PR DESCRIPTION
(Sorry about the earlier pull request. Was based on an outdated version of introsort)

The core crate seems to be referenced autoamtically in the latest rustc nightly.
The same goes for the core prelude. We can thus remove the core::prelude::\* imports.
I can't get rid of the final warning about core_slice_ext when building without float support.
